### PR TITLE
fix papers not darkened in backdrop and some warnings fixes

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.idea

--- a/client/src/ChoiceDialog.js
+++ b/client/src/ChoiceDialog.js
@@ -1,7 +1,7 @@
-import { Icon, IconButton, Paper, Dialog, DialogTitle, List, ListItem, ListItemIcon, ListItemText, Typography } from '@material-ui/core';
+import { Icon, Dialog, DialogTitle, List, ListItem, ListItemIcon, ListItemText, Typography } from '@material-ui/core';
 
 export default function SimpleDialog(props) {
-  const { onClose, selectedValue, open, items } = props;
+  const { onClose, open, items } = props;
 
   const handleClose = () => {
     onClose(null);

--- a/client/src/Form.js
+++ b/client/src/Form.js
@@ -20,6 +20,10 @@ const useStyles = makeStyles((theme) => ({
     width: "12%",
     height: "8ch"
   },
+  backdrop: {
+    zIndex: theme.zIndex.drawer + 1,
+    color: '#fff',
+  },
 }));
 
 // TODO: export

--- a/client/src/Form.js
+++ b/client/src/Form.js
@@ -209,7 +209,7 @@ function Form(props) {
   }
 
   function recomputeSplit(choices) {
-    let newSplit = Array(state.days).fill().map(() => [])
+    let newSplit = Array(state.days).fill([]);
     for (const day in choices) {
       newSplit[day] = Array.from(choices[day])
     }

--- a/client/src/Form.js
+++ b/client/src/Form.js
@@ -3,7 +3,7 @@ import { useState, useRef } from 'react';
 import { Collapse, Typography, Backdrop, CircularProgress, Button } from '@material-ui/core';
 import { Icon, IconButton } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
-import { InputGroup, IntegerField } from './InputGroup'
+import InputGroup, { IntegerField } from './InputGroup'
 import Alert from '@material-ui/lab/Alert';
 import SplitTable from './SplitTable'
 import ChoiceDialog from './ChoiceDialog'
@@ -50,8 +50,8 @@ const defaultPreferences = {
 }
 
 function makeDefaultPreference(group) {
-  var preference = {}
-  for (var other of defaultPreferences[group]) {
+  const preference = {};
+  for (const other of defaultPreferences[group]) {
     const name = group + '_preference_' + other 
     preference[name] = true
   }
@@ -105,12 +105,11 @@ const stateGroupKeys = {
 
 function getGroup(state, group) {
   const keys = stateGroupKeys[group]
-  const filtered = Object.fromEntries(
-    Object.entries(state).filter(
-      ([key, val]) => keys.includes(key)
-    )
-  );
-  return filtered
+  return Object.fromEntries(
+      Object.entries(state).filter(
+          ([key, val]) => keys.includes(key)
+      )
+  )
 }
 
 
@@ -132,8 +131,8 @@ function Form(props) {
       return 0
     }
 
-    var n = 0
-    for (var day of split) {
+    let n = 0;
+    for (const day of split) {
       if (day) {
         n = day.includes(group) ? n + 1 : n
       }
@@ -173,14 +172,14 @@ function Form(props) {
       return
     }
 
-    var form_data = new FormData();
-    for ( var key in state ) {
+    const form_data = new FormData();
+    for (const key in state ) {
       form_data.append(key, state[key]);
     }
     form_data.append('rest', JSON.stringify(rest.current))
     form_data.append('choices', JSON.stringify(choices.map(e => Array.from(e))))
 
-    var requestOptions = {
+    const requestOptions = {
       method: 'POST',
       body: form_data,
       redirect: 'follow'

--- a/client/src/InputGroup.js
+++ b/client/src/InputGroup.js
@@ -1,4 +1,4 @@
-import { React, useState } from 'react';
+import React, { useState } from 'react';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import { Checkbox, Typography, Grid, TextField } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';

--- a/client/src/SplitTable.js
+++ b/client/src/SplitTable.js
@@ -1,5 +1,5 @@
-import { TableRow, Typography } from '@material-ui/core';
-import { useTheme } from '@material-ui/core/styles';
+import {TableRow, Typography} from '@material-ui/core';
+import {useTheme} from '@material-ui/core/styles';
 
 function weekday(n) {
   return {0: 'LUNEDÌ', 1: 'MARTEDÌ', 2: 'MERCOLEDÌ',                          
@@ -62,27 +62,25 @@ function SplitTable(props) {
     const numbers = Array.from({length:props.days},(v,k)=>k+1)
     const split = props.split
 
-    const rows = numbers.map((n) => {
-      var cols = [[], [], []]
+    return numbers.map((n) => {
+      const cols = [[], [], []];
 
       if (split != null && n <= split.length) {
-        for (var group in groups) {
-          if (split[n-1].includes(group)) {
+        for (const group in groups) {
+          if (split[n - 1].includes(group)) {
             cols[groups[group]].push(mapGroup(group))
             groups[group] += 1
           }
         }
       }
       return (<SplitRow
-        key={n.toString()}
-        selected={props.selectedRow === n}
-        rest={props.rest ? props.rest[n-1] : false}
-        handleClick={props.handleClick}
-        row={n}
-        cols={cols} />);
-    });
-
-    return rows
+          key={n.toString()}
+          selected={props.selectedRow === n}
+          rest={props.rest ? props.rest[n - 1] : false}
+          handleClick={props.handleClick}
+          row={n}
+          cols={cols}/>);
+    })
   }
 
   return (


### PR DESCRIPTION
I fixed the papers which weren't darkened in backdrop when the circular progress is open.
I also fixed some warnings such as:
- replacing some var with let and const
- remove unused items