### PR TITLE
Move to react-to-print for better pdf generation

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2446,12 +2446,6 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
-    "@types/raf": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.0.tgz",
-      "integrity": "sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw==",
-      "optional": true
-    },
     "@types/react": {
       "version": "17.0.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.9.tgz",
@@ -3713,11 +3707,6 @@
         }
       }
     },
-    "base64-arraybuffer": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
-    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -3936,11 +3925,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
-    },
     "buffer": {
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
@@ -4101,20 +4085,6 @@
       "version": "1.0.30001233",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001233.tgz",
       "integrity": "sha512-BmkbxLfStqiPA7IEzQpIk0UFZFf3A4E6fzjPJ6OR+bFC2L8ES9J8zGA/asoi47p8XDVkev+WJo2I2Nc8c/34Yg=="
-    },
-    "canvg": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.7.tgz",
-      "integrity": "sha512-4sq6iL5Q4VOXS3PL1BapiXIZItpxYyANVzsAKpTPS5oq4u3SKbGfUcbZh2gdLCQ3jWpG/y5wRkMlBBAJhXeiZA==",
-      "optional": true,
-      "requires": {
-        "@babel/runtime-corejs3": "^7.9.6",
-        "@types/raf": "^3.4.0",
-        "raf": "^3.4.1",
-        "rgbcolor": "^1.0.1",
-        "stackblur-canvas": "^2.0.0",
-        "svg-pathdata": "^5.0.5"
-      }
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -4697,14 +4667,6 @@
             "uniq": "^1.0.1"
           }
         }
-      }
-    },
-    "css-line-break": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-1.0.1.tgz",
-      "integrity": "sha1-GfIGOjPpX7KDG4ZEbAuAwYivRQo=",
-      "requires": {
-        "base64-arraybuffer": "^0.1.5"
       }
     },
     "css-loader": {
@@ -5341,12 +5303,6 @@
       "requires": {
         "domelementtype": "1"
       }
-    },
-    "dompurify": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.9.tgz",
-      "integrity": "sha512-+9MqacuigMIZ+1+EwoEltogyWGFTJZWU3258Rupxs+2CGs4H914G9er6pZbsme/bvb5L67o2rade9n21e4RW/w==",
-      "optional": true
     },
     "domutils": {
       "version": "1.7.0",
@@ -6685,11 +6641,6 @@
         "bser": "2.1.1"
       }
     },
-    "fflate": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
-      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
-    },
     "figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -7483,14 +7434,6 @@
             "object.getownpropertydescriptors": "^2.0.3"
           }
         }
-      }
-    },
-    "html2canvas": {
-      "version": "1.0.0-alpha.12",
-      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.0.0-alpha.12.tgz",
-      "integrity": "sha1-OxmS48mz9WBjw1/WIElPN+uohRM=",
-      "requires": {
-        "css-line-break": "1.0.1"
       }
     },
     "htmlparser2": {
@@ -9830,46 +9773,6 @@
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
-      }
-    },
-    "jspdf": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.3.1.tgz",
-      "integrity": "sha512-1vp0USP1mQi1h7NKpwxjFgQkJ5ncZvtH858aLpycUc/M+r/RpWJT8PixAU7Cw/3fPd4fpC8eB/Bj42LnsR21YQ==",
-      "requires": {
-        "atob": "^2.1.2",
-        "btoa": "^1.2.1",
-        "canvg": "^3.0.6",
-        "core-js": "^3.6.0",
-        "dompurify": "^2.2.0",
-        "fflate": "^0.4.8",
-        "html2canvas": "^1.0.0-rc.5"
-      },
-      "dependencies": {
-        "base64-arraybuffer": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
-          "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
-          "optional": true
-        },
-        "css-line-break": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-1.1.1.tgz",
-          "integrity": "sha512-1feNVaM4Fyzdj4mKPIQNL2n70MmuYzAXZ1aytlROFX1JsOo070OsugwGjj7nl6jnDJWHDM8zRZswkmeYVWZJQA==",
-          "optional": true,
-          "requires": {
-            "base64-arraybuffer": "^0.2.0"
-          }
-        },
-        "html2canvas": {
-          "version": "1.0.0-rc.7",
-          "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.0.0-rc.7.tgz",
-          "integrity": "sha512-yvPNZGejB2KOyKleZspjK/NruXVQuowu8NnV2HYG7gW7ytzl+umffbtUI62v2dCHQLDdsK6HIDtyJZ0W3neerA==",
-          "optional": true,
-          "requires": {
-            "css-line-break": "1.1.1"
-          }
-        }
       }
     },
     "jss": {
@@ -12905,13 +12808,12 @@
         "workbox-webpack-plugin": "5.1.4"
       }
     },
-    "react-to-pdf": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/react-to-pdf/-/react-to-pdf-0.0.14.tgz",
-      "integrity": "sha512-u4gwkV7Byr1uU3FgR5n99tufNgMVEYE3reyjNsYK3WuRReE1IqolYXzCoj3n/Xhk8KOFYSiS3V4xEaGFGR9H5Q==",
+    "react-to-print": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/react-to-print/-/react-to-print-2.12.6.tgz",
+      "integrity": "sha512-O4hpQZX8pOd3W910n+WkT9Jvpd3tFcEWqTFHrm69bCGI/Nh5g2CoLrzaXObQW9BA9mK1K4+3qG88Q6DAJs+oWg==",
       "requires": {
-        "html2canvas": "1.0.0-alpha.12",
-        "jspdf": "^2.3.1"
+        "prop-types": "^15.7.2"
       }
     },
     "react-transition-group": {
@@ -13343,12 +13245,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
-    },
-    "rgbcolor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
-      "integrity": "sha1-1lBezbMEplldom+ktDMHMGd1lF0=",
-      "optional": true
     },
     "rimraf": {
       "version": "3.0.2",
@@ -14246,12 +14142,6 @@
         }
       }
     },
-    "stackblur-canvas": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.5.0.tgz",
-      "integrity": "sha512-EeNzTVfj+1In7aSLPKDD03F/ly4RxEuF/EX0YcOG0cKoPXs+SLZxDawQbexQDBzwROs4VKLWTOaZQlZkGBFEIQ==",
-      "optional": true
-    },
     "stackframe": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
@@ -14570,12 +14460,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
-    },
-    "svg-pathdata": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-5.0.5.tgz",
-      "integrity": "sha512-TAAvLNSE3fEhyl/Da19JWfMAdhSXTYeviXsLSoDT1UM76ADj5ndwAPX1FKQEgB/gFMPavOy6tOqfalXKUiXrow==",
-      "optional": true
     },
     "svgo": {
       "version": "1.3.2",

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",
-    "react-to-pdf": "0.0.14",
+    "react-to-print": "^2.12.6",
     "web-vitals": "^1.1.2"
   },
   "scripts": {

--- a/client/src/Form.js
+++ b/client/src/Form.js
@@ -8,7 +8,7 @@ import Alert from '@material-ui/lab/Alert';
 import SplitTable from './SplitTable'
 import ChoiceDialog from './ChoiceDialog'
 import InputTooltip from './InputTooltip'
-import ReactToPdf from 'react-to-pdf'
+import ReactToPrint from 'react-to-print';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -262,13 +262,7 @@ function Form(props) {
 
   }
 
-  const pdfOptions = {
-    orientation: 'landscape',
-    // unit: 'in',
-    // format: [4,2]
-  };
-
-
+  const componentRef = useRef();
 
   return (
     <div>
@@ -385,28 +379,26 @@ function Form(props) {
       </Button>
       <br/>
 
-      <ReactToPdf options={pdfOptions} filename='split.pdf' y={50}>
-        {({toPdf, targetRef}) =>  (
-          <div>
-            <div ref={targetRef}>
-              <SplitTable
-                selectedRow={selectedRow.current}
-                rest={rest.current}
-                handleClick={handleRowClick}
-                days={state.days}
-                split={split}
-                ref={targetRef}/>
-            </div>
-            <Button
-              onClick={toPdf}
-              align="left" variant="outlined" className={classes.button}>
-              <Typography>
-                <strong>Salva PDF</strong>
-              </Typography>
-            </Button>
-          </div>
-        )}
-      </ReactToPdf>
+      <div ref={componentRef}>
+        <SplitTable
+          selectedRow={selectedRow.current}
+          rest={rest.current}
+          handleClick={handleRowClick}
+          days={state.days}
+          split={split}
+        />
+      </div>
+      <ReactToPrint
+        trigger={() => 
+          <Button
+            align="left" variant="outlined" className={classes.button}>
+            <Typography>
+              <strong>Salva PDF</strong>
+            </Typography>
+          </Button>
+        }
+        content={() => componentRef.current}
+      />
 
       <ChoiceDialog items={groups.concat(['rest'])} onClose={handleCloseDialog} open={openDialog}>
       </ChoiceDialog>


### PR DESCRIPTION
Instead of using `react-to-pdf`, which generates a non-vectorized copy of a given React component, `react-to-print` allows to use the browser printing capabilities to export a well formed pdf.